### PR TITLE
Fix syntax highlighting for single quotes in strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.12.1](https://github.com/eliangelap/uniface-syntax-extension/compare/v1.12.0...v1.12.1) (2026-07-22)
+
+
+### Bug Fixes
+
+* **27:** 🐛 atualiza diagnósticos ao trocar de editor ([6a706df](https://github.com/eliangelap/uniface-syntax-extension/commit/6a706df4cc992f10387801a8d698add12c3bb957))
+* **sintaxe:** 🐛 corrige aspas simples em strings ([8a1ff24](https://github.com/eliangelap/uniface-syntax-extension/commit/8a1ff24702e218065cd070426e64f3ad3355506e))
+
 ## [1.12.0](https://github.com/eliangelap/uniface-syntax-extension/compare/v1.11.6...v1.12.0) (2026-07-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uniface-sintax-extension",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uniface-sintax-extension",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "dependencies": {
                 "standard-version": "9.5.0"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "uniface-syntax-extension",
     "displayName": "uniface-syntax-extension",
     "description": "A VSCode extension for Uniface program language, with syntax highlighter and all powerful of VSCode resources",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "scripts": {
         "vscode:prepublish": "npm run package",
         "compile": "npm run check-types && npm run lint && node esbuild.js",

--- a/src/__test__/unifaceGrammar.test.ts
+++ b/src/__test__/unifaceGrammar.test.ts
@@ -26,13 +26,18 @@ suite('Uniface TextMate grammar', () => {
         const grammar = JSON.parse(fs.readFileSync(getGrammarPath(), 'utf8')) as {
             repository: { strings: { patterns: TextMatePattern[] } };
         };
-        const stringPattern = grammar.repository.strings.patterns[0];
+        const stringPatterns = grammar.repository.strings.patterns;
 
-        assert.strictEqual(stringPattern.name, 'string.quoted.double.uniface');
-        assert.strictEqual(stringPattern.begin, '"');
-        assert.strictEqual(stringPattern.end, '"');
+        const doubleQuotePattern = stringPatterns.find(
+            (pattern) => pattern.begin === '"' && pattern.end === '"'
+        );
+        assert.ok(doubleQuotePattern, 'Expected a double-quoted string pattern.');
+        assert.strictEqual(doubleQuotePattern.name, 'string.quoted.double.uniface');
+        assert.strictEqual(doubleQuotePattern.begin, '"');
+        assert.strictEqual(doubleQuotePattern.end, '"');
+
         assert.strictEqual(
-            stringPattern.patterns?.some((pattern) => pattern.begin === "'"),
+            stringPatterns.some((pattern) => pattern.begin === "'"),
             false
         );
     });

--- a/src/__test__/unifaceGrammar.test.ts
+++ b/src/__test__/unifaceGrammar.test.ts
@@ -1,0 +1,51 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+interface TextMatePattern {
+    name?: string;
+    begin?: string;
+    end?: string;
+    match?: string;
+    patterns?: TextMatePattern[];
+}
+
+suite('Uniface TextMate grammar', () => {
+    function getGrammarPath(): string {
+        const extension = vscode.extensions.all.find(
+            (candidate) => candidate.packageJSON.name === 'uniface-syntax-extension'
+        );
+
+        assert.ok(extension, 'The Uniface extension must be loaded for grammar tests.');
+
+        return path.join(extension.extensionPath, 'syntaxes', 'uniface.tmLanguage.json');
+    }
+
+    test('treats only double quotes as string delimiters', () => {
+        const grammar = JSON.parse(fs.readFileSync(getGrammarPath(), 'utf8')) as {
+            repository: { strings: { patterns: TextMatePattern[] } };
+        };
+        const stringPattern = grammar.repository.strings.patterns[0];
+
+        assert.strictEqual(stringPattern.name, 'string.quoted.double.uniface');
+        assert.strictEqual(stringPattern.begin, '"');
+        assert.strictEqual(stringPattern.end, '"');
+        assert.strictEqual(
+            stringPattern.patterns?.some((pattern) => pattern.begin === "'"),
+            false
+        );
+    });
+
+    test('matches longer escapes before their prefixes', () => {
+        const grammar = JSON.parse(fs.readFileSync(getGrammarPath(), 'utf8')) as {
+            repository: { strings: { patterns: TextMatePattern[] } };
+        };
+        const escapePatterns = grammar.repository.strings.patterns[0].patterns ?? [];
+
+        assert.deepStrictEqual(
+            escapePatterns.map((pattern) => pattern.match),
+            ['%%%', '%%"', '%%']
+        );
+    });
+});

--- a/src/__test__/unifaceGrammar.test.ts
+++ b/src/__test__/unifaceGrammar.test.ts
@@ -46,7 +46,12 @@ suite('Uniface TextMate grammar', () => {
         const grammar = JSON.parse(fs.readFileSync(getGrammarPath(), 'utf8')) as {
             repository: { strings: { patterns: TextMatePattern[] } };
         };
-        const escapePatterns = grammar.repository.strings.patterns[0].patterns ?? [];
+        const stringPatterns = grammar.repository.strings.patterns;
+        const doubleQuotePattern = stringPatterns.find(
+            (pattern) => pattern.begin === '"' && pattern.end === '"'
+        );
+        assert.ok(doubleQuotePattern, 'Expected a double-quoted string pattern.');
+        const escapePatterns = doubleQuotePattern.patterns ?? [];
 
         assert.deepStrictEqual(
             escapePatterns.map((pattern) => pattern.match),

--- a/syntaxes/uniface.tmLanguage.json
+++ b/syntaxes/uniface.tmLanguage.json
@@ -56,11 +56,9 @@
             ]
         },
         "strings": {
-            "name": "string.quoted.double.uniface",
-            "begin": "\"",
-            "end": "\"",
             "patterns": [
                 {
+                    "name": "string.quoted.double.uniface",
                     "begin": "\"",
                     "beginCaptures": {
                         "0": {
@@ -72,34 +70,21 @@
                         "0": {
                             "name": "punctuation.definition.string.end.uniface"
                         }
-                    }
-                },
-                {
-                    "begin": "'",
-                    "beginCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.string.begin.uniface"
-                        }
                     },
-                    "end": "'",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.string.end.uniface"
+                    "patterns": [
+                        {
+                            "match": "%%%",
+                            "name": "constant.character.escape.uniface"
+                        },
+                        {
+                            "match": "%%\"",
+                            "name": "constant.character.escape.uniface"
+                        },
+                        {
+                            "match": "%%",
+                            "name": "constant.character.escape.uniface"
                         }
-                    },
-                    "name": "string.quoted.single.uniface"
-                },
-                {
-                    "match": "%%\"",
-                    "name": "constant.character.escape.uniface"
-                },
-                {
-                    "match": "%%",
-                    "name": "constant.character.escape.uniface"
-                },
-                {
-                    "match": "%%%",
-                    "name": "constant.character.escape.uniface"
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
This pull request addresses a bug in the Uniface syntax extension related to string handling and escape sequences. The main focus is to ensure that only double quotes are treated as string delimiters and to correctly prioritize escape sequence matching. Additionally, automated tests have been added to verify the grammar behavior.

**Syntax and Grammar Fixes:**

* Updated `uniface.tmLanguage.json` to only recognize double quotes (`"`) as string delimiters, removing support for single-quoted strings. [[1]](diffhunk://#diff-3c9e286adb88859240032baffd80336c1a8315fe6817fa04e9942f6fef495d96L59-R61) [[2]](diffhunk://#diff-3c9e286adb88859240032baffd80336c1a8315fe6817fa04e9942f6fef495d96L75-R77)
* Adjusted the escape sequence patterns so that longer escapes (e.g., `%%%`) are matched before their prefixes (e.g., `%%`). [[1]](diffhunk://#diff-3c9e286adb88859240032baffd80336c1a8315fe6817fa04e9942f6fef495d96L75-R77) [[2]](diffhunk://#diff-3c9e286adb88859240032baffd80336c1a8315fe6817fa04e9942f6fef495d96L99-R87)

**Testing Improvements:**

* Added a new test suite in `src/__test__/unifaceGrammar.test.ts` to verify that only double quotes delimit strings and that escape sequences are matched in the correct order.

**Documentation and Versioning:**

* Updated `CHANGELOG.md` to document the bug fixes in version 1.12.1, specifically the string delimiter and diagnostics update.
* Bumped the extension version to `1.12.1` in `package.json`.